### PR TITLE
docs: Add FIGMA_TOKEN to the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to play with it then:
 
 1.  Clone this repo
 2.  Run `yarn install`
-3.  Run `yarn run dev`
+3.  Run `FIGMA_TOKEN={YOUR_PERSONAL_FIGMA_TOKEN} yarn run dev`
 4.  Go to `http://localhost:3001/` and have fun!
 
 ## Query examples


### PR DESCRIPTION
Right now it's not clear how to use the personal token. It took me quite some time and I had to dig into source code to understand that. I believe if the documentation has it upfront it can save a lot of time of other fellow developers.