### PR TITLE
Add images and comments to file query

### DIFF
--- a/src/__tests__/file.test.js
+++ b/src/__tests__/file.test.js
@@ -19,4 +19,20 @@ describe("File", () => {
             data: { file: { name: "figma-graphql test file" } },
         });
     });
+
+    test("can get file default images", async () => {
+        const query = `
+            query {
+                file(id: "${figmaFile}") {
+                    images {
+                        id
+                    }
+                }
+            }
+        `;
+
+        await expect(graphql(schema, query, null, { fileId: figmaFile })).resolves.toEqual({
+            data: { file: { images: [{ id: "0:1" }] } },
+        });
+    });
 });

--- a/src/__tests__/file.test.js
+++ b/src/__tests__/file.test.js
@@ -35,4 +35,54 @@ describe("File", () => {
             data: { file: { images: [{ id: "0:1" }] } },
         });
     });
+
+    test("can get file comments", async () => {
+        const query = `
+            query {
+                file(id: "${figmaFile}") {
+                    comments {
+                        id
+                        message
+                        file_key
+                        order_id
+                        parent_id
+                        created_at
+                        client_meta {
+                                  node_id
+                          node_offset {
+                            x
+                            y
+                          }
+                        }
+                        resolved_at
+                      }
+                }
+            }
+        `;
+
+        await expect(graphql(schema, query, null, { fileId: figmaFile })).resolves.toEqual({
+            data: {
+                file: {
+                    comments: [
+                        {
+                            id: "6907475",
+                            message: "Testing comment",
+                            file_key: "cLp23bR627jcuNSoBGkhL04E",
+                            order_id: 1,
+                            parent_id: "",
+                            created_at: "2019-05-26T17:47:36Z",
+                            client_meta: {
+                                node_id: "28:5",
+                                node_offset: {
+                                    x: 111,
+                                    y: 22,
+                                },
+                            },
+                            resolved_at: null,
+                        },
+                    ],
+                },
+            },
+        });
+    });
 });

--- a/src/types/comments.js
+++ b/src/types/comments.js
@@ -31,7 +31,7 @@ exports.type = `
         id: ID!
 
         # The position of the comment. Either the absolute coordinates on the canvas or a relative offset within a frame
-        client_meta: Position
+        client_meta: FrameOffset
 
         # The file in which the comment lives
         file_key: String

--- a/src/types/file.js
+++ b/src/types/file.js
@@ -1,5 +1,5 @@
 const { gql } = require("apollo-server-express");
-const { loadFigmaFile, loadFigmaImages } = require("../utils/figma");
+const { loadFigmaFile, loadFigmaImages, loadFigmaComments } = require("../utils/figma");
 const {
     generateResolversForShortcuts,
     generateQueriesForShortcuts,
@@ -21,8 +21,11 @@ exports.type = gql`
         # Current version of the file
         version: String
 
-        # Get images for that file
+        # Get images for the file
         images(params: ImageParams): [Image]
+
+        # Get comments for the file
+        comments: [Comment]
 
         ${generateQueriesForShortcuts()}
     }
@@ -43,6 +46,7 @@ exports.resolvers = {
             const { images } = await loadFigmaImages(fileId, imageParams);
             return Object.entries(images).map(entry => ({ id: entry[0], file: entry[1] }));
         },
+        comments: (_, __, { fileId }) => loadFigmaComments(fileId).then(data => data.comments),
         ...generateResolversForShortcuts(),
     },
 };

--- a/src/types/image.js
+++ b/src/types/image.js
@@ -1,5 +1,8 @@
 const { loadFigmaImages } = require("../utils/figma");
 
+const defaultImageParams = { ids: ["0:1"] };
+exports.defaultImageParams = defaultImageParams;
+
 exports.type = `
     enum ImageFormat {
         jpg
@@ -17,24 +20,32 @@ exports.type = `
         # A string enum for the image output format, can be "jpg", "png", or "svg"
         format: ImageFormat
     }
-    
+
+    input ImageNodeParams {
+        # A number between 0.01 and 4, the image scaling factor
+        scale: Int
+
+        # A string enum for the image output format, can be "jpg", "png", or "svg"
+        format: ImageFormat
+    }
+
     type Image {
-        # Images for the ID's you requested
-        images: [ID]!
+        id: String
+        file: String
     }
 
     extend type Query {
         # Get just the image of a node id in a file
-        image(id: ID!, params: ImageParams): Image
+        images(id: ID!, params: ImageParams): [Image]
     }
 `;
 
 exports.resolvers = {
     Query: {
-        image: (root, { id, params = { ids: ["0:1"] } }) =>
-            loadFigmaImages(id, params).then(data => data),
-    },
-    Image: {
-        images: ({ images = [] }) => Object.values(images),
+        images: async (root, { id, params }) => {
+            const imageParams = { ...defaultImageParams, ...params };
+            const { images } = await loadFigmaImages(id, imageParams).then(data => data);
+            return Object.entries(images).map(entry => ({ id: entry[0], file: entry[1] }));
+        },
     },
 };

--- a/src/types/node.js
+++ b/src/types/node.js
@@ -18,7 +18,7 @@ const nodeProperties = `
     type: NodeType!
 
     # Additional properties
-    image(params: ImageParams): String
+    image(params: ImageNodeParams): Image
 `;
 
 const nodeTypes = [
@@ -66,7 +66,7 @@ exports.resolvers = {
                 ids: sources.map(({ id }) => id),
             });
 
-            return Object.values(images);
+            return Object.entries(images).map(entry => ({ id: entry[0], file: entry[1] }));
         }),
         visible: root => get(root, "visible", true),
     },


### PR DESCRIPTION
This adds the possibility of querying for images and comments inside the file query.

For the comments it allows us to do this (both return the same data)
```gql
{
  comments(id: "cLp23bR627jcuNSoBGkhL04E") {
    id
    message
  }
  file(id: "cLp23bR627jcuNSoBGkhL04E") {
    comments {
      id
      message
    }
  }
}
```
For the images we can do something like this:
```gql
{
  images(id: "cLp23bR627jcuNSoBGkhL04E") {
    id
    file
  }
  file(id: "cLp23bR627jcuNSoBGkhL04E") {
    images(params: { ids: ["0:1"]}) {
      id
      file
    }
    pages {
      image {
        id
        file
      }
    }
  }
}
```

Fixes #3 