### PR TITLE
Stitch teams, projects and files together

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,17 +4,13 @@ const cors = require("cors");
 const express = require("express");
 const { ApolloServer } = require("apollo-server-express");
 
-const { loadFigmaFile } = require("./utils/figma");
-const { getFileId } = require("./utils/helpers");
+const { loadFile } = require("./utils/figma");
 const { schema } = require("./schema");
 
 const PORT = 3001;
 
 const server = new ApolloServer({
     schema,
-    context: async ({ req }) => ({
-        fileId: getFileId(req.body.query),
-    }),
 });
 
 const app = express();
@@ -24,7 +20,7 @@ server.applyMiddleware({ app });
 // Get figma API response (just for testing)
 app.get("/figma/:id", (req, res) => {
     const { id } = req.params;
-    loadFigmaFile(id).then(data => {
+    loadFile(id).then(data => {
         res.json(data);
     });
 });

--- a/src/types/comments.js
+++ b/src/types/comments.js
@@ -1,4 +1,4 @@
-const { loadFigmaComments, createComment } = require("../utils/figma");
+const { loadComments, createComment } = require("../utils/figma");
 
 exports.type = `
     type User {
@@ -68,7 +68,7 @@ exports.type = `
 
 exports.resolvers = {
     Query: {
-        comments: (root, { id }) => loadFigmaComments(id).then(data => data.comments),
+        comments: (root, { id }) => loadComments(id).then(data => data.comments),
     },
     Mutation: {
         addComment: (root, { id, message, params }) =>

--- a/src/types/file.js
+++ b/src/types/file.js
@@ -1,5 +1,5 @@
 const { gql } = require("apollo-server-express");
-const { loadFigmaFile, loadFigmaImages, loadFigmaComments } = require("../utils/figma");
+const { loadFile, loadImages, loadComments } = require("../utils/figma");
 const {
     generateResolversForShortcuts,
     generateQueriesForShortcuts,
@@ -38,15 +38,15 @@ exports.type = gql`
 
 exports.resolvers = {
     Query: {
-        file: (_, { id }) => loadFigmaFile(id).then(data => data),
+        file: (_, { id }) => loadFile(id).then(data => data),
     },
     File: {
-        images: async (_, { params }, { fileId }) => {
+        images: async ({ fileId }, { params }) => {
             const imageParams = { ...defaultImageParams, ...params };
-            const { images } = await loadFigmaImages(fileId, imageParams);
+            const { images } = await loadImages(fileId, imageParams);
             return Object.entries(images).map(entry => ({ id: entry[0], file: entry[1] }));
         },
-        comments: (_, __, { fileId }) => loadFigmaComments(fileId).then(data => data.comments),
+        comments: (_, __, { fileId }) => loadComments(fileId).then(data => data.comments),
         ...generateResolversForShortcuts(),
     },
 };

--- a/src/types/image.js
+++ b/src/types/image.js
@@ -1,4 +1,4 @@
-const { loadFigmaImages } = require("../utils/figma");
+const { loadImages } = require("../utils/figma");
 
 const defaultImageParams = { ids: ["0:1"] };
 exports.defaultImageParams = defaultImageParams;
@@ -44,7 +44,7 @@ exports.resolvers = {
     Query: {
         images: async (root, { id, params }) => {
             const imageParams = { ...defaultImageParams, ...params };
-            const { images } = await loadFigmaImages(id, imageParams).then(data => data);
+            const { images } = await loadImages(id, imageParams).then(data => data);
             return Object.entries(images).map(entry => ({ id: entry[0], file: entry[1] }));
         },
     },

--- a/src/types/project-files.js
+++ b/src/types/project-files.js
@@ -1,26 +1,20 @@
-const { loadProjectFiles } = require("../utils/figma");
+const { loadProjectFiles, loadFile } = require("../utils/figma");
 
 exports.type = `
-    # A file inside a project
-    type ProjectFile {
-     # Key of this file
-     key: String
-     # Name of the file
-     name: String
-     # Thumbnail of the file
-     thumbnail_url: String
-     # Date when last modified
-     last_modified: String
-    }
-
     extend type Query {
         # Get a projects files
-        projectFiles(project: String!): [ProjectFile]
+        projectFiles(projectId: String!): [File]
     }
 `;
 
 exports.resolvers = {
     Query: {
-        projectFiles: (root, { project }) => loadProjectFiles(project).then(data => data.files),
+        projectFiles: async (_, { projectId }) => {
+            const { files: projectFiles } = await loadProjectFiles(projectId);
+
+            const parsedFiles = await Promise.all(projectFiles.map(({ key }) => loadFile(key)));
+
+            return Object.values(parsedFiles);
+        },
     },
 };

--- a/src/utils/figma.js
+++ b/src/utils/figma.js
@@ -7,7 +7,7 @@ const client = Figma.Client({
 
 const { file, fileImages, comments, postComment, teamProjects, projectFiles } = client;
 
-function getFigma(label, fn, id, params, normalise = false) {
+function getFigma(label, fn, id, params) {
     return new Promise((resolve, reject) => {
         const withParams = params ? { ...params } : null;
 
@@ -15,12 +15,13 @@ function getFigma(label, fn, id, params, normalise = false) {
         console.log("fetching", label, id);
         fn(id, withParams)
             .then(({ data }) => {
-                if (normalise) {
+                if (label === "file") {
                     const { name, lastModified, thumbnailUrl, version, document, styles } = data;
 
-                    const [processedNodes, processedShortcuts] = processNodes(document, styles);
+                    const [processedNodes, processedShortcuts] = processNodes(document, styles, id);
 
                     const result = {
+                        fileId: id,
                         name,
                         lastModified,
                         thumbnailUrl,
@@ -38,11 +39,11 @@ function getFigma(label, fn, id, params, normalise = false) {
     });
 }
 
-exports.loadFigmaFile = id => getFigma("file", file, id, null, true);
+exports.loadFile = id => getFigma("file", file, id, null);
 
-exports.loadFigmaComments = id => getFigma("comments", comments, id, null, false);
+exports.loadComments = id => getFigma("comments", comments, id, null);
 
-exports.loadFigmaImages = (id, params) => getFigma("images", fileImages, id, params, false);
+exports.loadImages = (id, params) => getFigma("images", fileImages, id, params);
 
 exports.loadTeamProjects = id => getFigma("projects", teamProjects, id);
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -7,10 +7,3 @@ exports.getSize = node => ({
     width: node.absoluteBoundingBox.width,
     height: node.absoluteBoundingBox.height,
 });
-
-exports.getFileId = str => {
-    const regex = /file\(id: "(\w+)"\)/g;
-    const res = regex.exec(str);
-
-    return res && res[1];
-};

--- a/src/utils/nodes.js
+++ b/src/utils/nodes.js
@@ -29,7 +29,7 @@ exports.getNodes = (data, nodeType, filterBy) => {
     return dataNodes;
 };
 
-exports.processNodes = (nodes, documentStyles) => {
+exports.processNodes = (nodes, documentStyles, fileId) => {
     const parsedStyles = new Map(Object.entries(documentStyles));
 
     const traverseChildren = (node, parentId) => {
@@ -52,7 +52,7 @@ exports.processNodes = (nodes, documentStyles) => {
 
         // Reached a leaf so returning the simplified node
         if (children == null || children.length === 0) {
-            return [[{ id, parentId, ...rest }], nodeStyles];
+            return [[{ id, parentId, fileId, ...rest }], nodeStyles];
         }
 
         // If it gets here then it means it has children
@@ -75,6 +75,7 @@ exports.processNodes = (nodes, documentStyles) => {
         const parsedNode = {
             id,
             parentId,
+            fileId,
             ...rest,
             children: parsedChildren,
             shortcuts: groupNodes(shortcuts),


### PR DESCRIPTION
This brings teams, projects and files together so we can go get all properties available on each file for the entire team/project.

It enables some really interesting things for organisations and allows them to do things like: 
```gql
{
  projects(teamId: "707291103567524770") {
    id
    name
    files {
      name
      pages {
        name
      }
    }
  }
}
```
to get the names of the pages in all files inside a team:
```json
{
  "data": {
    "projects": [
      {
        "id": "2482679",
        "name": "Design System",
        "files": [
          {
            "name": "Figma GraphQL",
            "pages": [
              {
                "name": "Assets"
              },
              {
                "name": "GraphQL Conf Presentation"
              }
            ]
          },
          {
            "name": "Figma-GraphQL Colors",
            "pages": [
              {
                "name": "Page 1"
              }
            ]
          },
          {
            "name": "Wûnderzin UI Kit",
            "pages": [
              {
                "name": "pages"
              },
              {
                "name": "preview modules"
              },
              {
                "name": "base modules"
              },
              {
                "name": "article modules"
              },
              {
                "name": "forms"
              },
              {
                "name": "controls"
              },
              {
                "name": "icons"
              },
              {
                "name": "styles"
              }
            ]
          }
        ]
      },
      {
        "id": "2482707",
        "name": "Test",
        "files": [
          {
            "name": "Simple Test",
            "pages": [
              {
                "name": "Page 1"
              }
            ]
          },
          {
            "name": "Untitled",
            "pages": [
              {
                "name": "Page"
              }
            ]
          },
          {
            "name": "figma-graphql test file",
            "pages": [
              {
                "name": "Page 1"
              },
              {
                "name": "Page 2"
              }
            ]
          }
        ]
      }
    ]
  }
}
```
We can also do a similar query for the project files directly:
```gql
{
  projectFiles(projectId: "2482707") {
    name
    pages {
      name
    }
  }
}
```

Fixes #4 