### PR TITLE
Add cache support

### DIFF
--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -58,7 +58,7 @@ export const type = gql`
 
     extend type Query {
         # Get Comments on a File
-        comments(id: ID!): [Comment]
+        comments(id: ID!, noCache: Boolean): [Comment]
     }
 
     extend type Mutation {
@@ -69,10 +69,11 @@ export const type = gql`
 
 export const resolvers = {
     Query: {
-        comments: (root, { id }) => loadComments(id).then(({ comments }) => comments),
+        comments: (_: never, { id, noCache }) =>
+            loadComments(id, noCache).then(({ comments }) => comments),
     },
     Mutation: {
-        addComment: (root, { id, message, params }) =>
+        addComment: (_: never, { id, message, params }) =>
             // eslint-disable-next-line @typescript-eslint/camelcase
             createComment(id, { client_meta: { ...params }, message }).then(data => data),
     },

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -29,13 +29,14 @@ export const type = gql`
 
     extend type Query {
         # get a file information
-        file(id: ID!): File
+        file(id: ID!, noCache: Boolean): File
     }
 `;
 
 export const resolvers = {
     Query: {
-        file: (_, { id }) => loadFile(id).then(data => data),
+        file: (_: never, { id, noCache }: { id: string; noCache: boolean }) =>
+            loadFile(id, noCache).then(data => data),
     },
     File: {
         exports: async ({ fileId }, { params }) => {

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -38,7 +38,7 @@ export const nodeTypes = [
     "COMPONENT",
     "INSTANCE",
     "STYLE",
-];
+] as const;
 
 export const type = gql`
     enum NodeType {

--- a/src/types/project-files.ts
+++ b/src/types/project-files.ts
@@ -4,16 +4,18 @@ import { loadProjectFiles, loadFile } from "../utils/figma";
 export const type = gql`
     extend type Query {
         # Get a projects files
-        projectFiles(projectId: String!): [File]
+        projectFiles(projectId: String!, noCache: Boolean): [File]
     }
 `;
 
 export const resolvers = {
     Query: {
-        projectFiles: async (_, { projectId }) => {
-            const { files: projectFiles } = await loadProjectFiles(projectId);
+        projectFiles: async (_: never, { projectId, noCache }) => {
+            const { files: projectFiles } = await loadProjectFiles(projectId, noCache);
 
-            const parsedFiles = await Promise.all(projectFiles.map(({ key }) => loadFile(key)));
+            const parsedFiles = await Promise.all(
+                projectFiles.map(({ key }) => loadFile(key, noCache))
+            );
 
             return Object.values(parsedFiles);
         },

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -15,13 +15,14 @@ export const type = gql`
 
     extend type Query {
         # Get a teams projects
-        projects(teamId: ID!): [Project]
+        projects(teamId: ID!, noCache: Boolean): [Project]
     }
 `;
 
 export const resolvers = {
     Query: {
-        projects: (root, { teamId }) => loadTeamProjects(teamId).then(({ projects }) => projects),
+        projects: (_: never, { teamId, noCache }) =>
+            loadTeamProjects(teamId, noCache).then(({ projects }) => projects),
     },
     Project: {
         files: createBatchResolver<{ id: string }, any>(async projects => {

--- a/src/utils/figma.ts
+++ b/src/utils/figma.ts
@@ -6,68 +6,155 @@ import {
     CommentsResponse,
     TeamProjectsResponse,
     ProjectFilesResponse,
+    FileParams,
+    Node,
+    FileResponse,
 } from "figma-js";
 import { config } from "dotenv";
 import { processNodes, groupNodes } from "./nodes";
 
 config();
 
+// Setup types
+enum RequestType {
+    File,
+    Comments,
+    Images,
+    Projects,
+    ProjectFiles,
+    PostComment,
+}
+
+type FigmaOptions = {
+    requestType: RequestType;
+    id: string;
+    params?: FileParams | FileImageParams | PostCommentParams;
+    noCache?: boolean;
+};
+
+type CustomFileResponse = {
+    fileId: string;
+    name: string;
+    lastModified: string;
+    thumbnailUrl: string;
+    version: string;
+    children: any;
+    shortcuts: Record<string, Node[]>;
+};
+
+type FigmaResponse =
+    | CustomFileResponse
+    | FileImageResponse
+    | Comment
+    | CommentsResponse
+    | TeamProjectsResponse
+    | ProjectFilesResponse;
+
+// Initialise FigmaJS Client and import all necessary functions
 const client = Client({
     personalAccessToken: process.env.FIGMA_TOKEN,
 });
 
 const { file, fileImages, comments, postComment, teamProjects, projectFiles } = client;
 
-function getFigma(
-    label: string,
-    fn,
-    id: string,
-    params: FileImageParams | PostCommentParams | null
-): Promise<any> {
-    return new Promise((resolve, reject) => {
-        const withParams = params ? { ...params } : null;
+const mapTypeToFunctionWithParams = {
+    [RequestType.File]: file,
+    [RequestType.Images]: fileImages,
+    [RequestType.PostComment]: postComment,
+};
 
-        // eslint-disable-next-line no-console
-        console.log("fetching", label, id);
-        fn(id, withParams)
-            .then(({ data }) => {
-                if (label === "file") {
-                    const { name, lastModified, thumbnailUrl, version, document, styles } = data;
+const mapTypeToFunction = {
+    [RequestType.Comments]: comments,
+    [RequestType.Projects]: teamProjects,
+    [RequestType.ProjectFiles]: projectFiles,
+};
 
-                    const [processedNodes, processedShortcuts] = processNodes(document, styles, id);
+type Values<O extends object> = O[keyof O];
 
-                    const result = {
-                        fileId: id,
-                        name,
-                        lastModified,
-                        thumbnailUrl,
-                        version,
-                        children: processedNodes,
-                        shortcuts: groupNodes(processedShortcuts),
-                    };
+type FigmaFunction =
+    | ((id: string) => ReturnType<Values<typeof mapTypeToFunction>>)
+    | ((
+          id: string,
+          params?: FileParams | FileImageParams | PostCommentParams
+      ) => ReturnType<Values<typeof mapTypeToFunctionWithParams>>);
 
-                    resolve(result);
-                } else {
-                    resolve(data);
-                }
-            })
-            .catch(reject);
-    });
+// Initialise cache
+const cache = new Map();
+
+function buildCustomFileReponse(data: FileResponse, id: string): CustomFileResponse {
+    const { name, lastModified, thumbnailUrl, version, document, styles } = data;
+
+    const [processedNodes, processedShortcuts] = processNodes(document, styles, id);
+
+    return {
+        fileId: id,
+        name,
+        lastModified,
+        thumbnailUrl,
+        version,
+        children: processedNodes[0].children,
+        shortcuts: groupNodes(processedShortcuts),
+    };
 }
 
-export const loadFile = (id: string) => getFigma("file", file, id, null);
+async function getFigma<T extends FigmaResponse>({
+    requestType,
+    id,
+    params,
+    noCache = false,
+}: FigmaOptions): Promise<T> {
+    const key = `${id}_${requestType}`;
 
-export const loadComments = (id: string): Promise<CommentsResponse> =>
-    getFigma("comments", comments, id, null);
+    if (noCache === false && params === undefined && cache.has(key)) {
+        // eslint-disable-next-line no-console
+        console.log("returning from cache", key);
+        return cache.get(key);
+    }
+    // eslint-disable-next-line no-console
+    console.log("fetching", key);
+
+    const fn: FigmaFunction =
+        params !== undefined
+            ? mapTypeToFunction[requestType]
+            : mapTypeToFunctionWithParams[requestType];
+
+    try {
+        const { data } = await fn(id, { ...params });
+
+        // We just need to parse the response if it's for a file, otherwise we return the raw data
+        const processedData = "document" in data ? buildCustomFileReponse(data, id) : data;
+
+        // Only store data that doesn't change depending on the params
+        // We store it even if noCache is true so we can update the cache
+        if (params === undefined) {
+            cache.set(key, processedData);
+        }
+
+        return processedData as T;
+    } catch (e) {
+        throw new Error("Problem fetching data");
+    }
+}
+
+export const loadFile = (id: string, noCache: boolean = false): Promise<CustomFileResponse> =>
+    getFigma({ requestType: RequestType.File, id, noCache });
+
+export const loadComments = (id: string, noCache: boolean = false): Promise<CommentsResponse> =>
+    getFigma({ requestType: RequestType.Comments, id, noCache });
 
 export const loadImages = (id: string, params: FileImageParams): Promise<FileImageResponse> =>
-    getFigma("images", fileImages, id, params);
+    getFigma({ requestType: RequestType.Images, id, params });
 
-export const loadTeamProjects = (id: string): Promise<TeamProjectsResponse> =>
-    getFigma("projects", teamProjects, id, null);
+export const loadTeamProjects = (
+    id: string,
+    noCache: boolean = false
+): Promise<TeamProjectsResponse> => getFigma({ requestType: RequestType.Projects, id, noCache });
 
-export const loadProjectFiles = (id: string): Promise<ProjectFilesResponse> =>
-    getFigma("projectFiles", projectFiles, id, null);
+export const loadProjectFiles = (
+    id: string,
+    noCache: boolean = false
+): Promise<ProjectFilesResponse> =>
+    getFigma({ requestType: RequestType.ProjectFiles, id, noCache });
 
-export const createComment = (id: string, params: PostCommentParams): Promise<CommentsResponse> =>
-    getFigma("postComment", postComment, id, params);
+export const createComment = (id: string, params: PostCommentParams): Promise<Comment> =>
+    getFigma({ requestType: RequestType.PostComment, id, params });

--- a/src/utils/figma.ts
+++ b/src/utils/figma.ts
@@ -64,6 +64,7 @@ const mapTypeToFunctionWithParams = {
 };
 
 const mapTypeToFunction = {
+    [RequestType.File]: file,
     [RequestType.Comments]: comments,
     [RequestType.Projects]: teamProjects,
     [RequestType.ProjectFiles]: projectFiles,
@@ -114,7 +115,7 @@ async function getFigma<T extends FigmaResponse>({
     console.log("fetching", key);
 
     const fn: FigmaFunction =
-        params !== undefined
+        params === undefined
             ? mapTypeToFunction[requestType]
             : mapTypeToFunctionWithParams[requestType];
 
@@ -122,7 +123,10 @@ async function getFigma<T extends FigmaResponse>({
         const { data } = await fn(id, { ...params });
 
         // We just need to parse the response if it's for a file, otherwise we return the raw data
-        const processedData = "document" in data ? buildCustomFileReponse(data, id) : data;
+        const processedData =
+            "document" in data && requestType === RequestType.File
+                ? buildCustomFileReponse(data, id)
+                : data;
 
         // Only store data that doesn't change depending on the params
         // We store it even if noCache is true so we can update the cache
@@ -132,7 +136,7 @@ async function getFigma<T extends FigmaResponse>({
 
         return processedData as T;
     } catch (e) {
-        throw new Error("Problem fetching data");
+        throw new Error(e);
     }
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,7 +14,8 @@ export const getSize = node => ({
 export const addUnit = (string?: string | number, unit: string = "px") =>
     string != null ? `${string}${unit}` : string;
 
-export const getColor = ({ r, g, b, a }: Color, mode: ColorMode) => `rgba(${r}, ${g}, ${b}, ${a})`;
+export const getColor = ({ r, g, b, a }: Color, mode: ColorMode) =>
+    mode === ColorMode.RGB ? `rgba(${r}, ${g}, ${b}, ${a})` : "none";
 
 export const JSToCSS = cssObject => {
     return Object.entries(cssObject)

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -2,7 +2,8 @@ import groupBy from "lodash/groupBy";
 import uniqBy from "lodash/uniqBy";
 import { Node } from "figma-js";
 
-export const groupNodes = (nodes: Node[]) => groupBy(uniqBy(nodes, "id"), "type");
+export const groupNodes = (nodes: Node[]): Record<string, Node[]> =>
+    groupBy(uniqBy(nodes, "id"), "type");
 
 export const getNodes = (data, nodeType, filterBy) => {
     const { name: filterByName, type: filterByType } = filterBy;


### PR DESCRIPTION
This adds a smarter cache to the Figma requests. 

It doesn't try to cache any of the requests that have parameters so we don't have problems with the more "dynamic" data.

Also added a `noCache` option for all of the cacheable queries so we can bypass the cache (or update it) through the GraphQL query directly.

Fixes #20  