### PR TITLE
chore: update souporserious profile URL

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -51,7 +51,7 @@
       "login": "souporserious",
       "name": "Travis Arnold",
       "avatar_url": "https://avatars1.githubusercontent.com/u/2762082?v=4",
-      "profile": "http://travisrayarnold.com",
+      "profile": "https://souporserious.com",
       "contributions": [
         "doc"
       ]


### PR DESCRIPTION
Someone snagged my old domain which now redirects to a porn site 🤦‍♂ this fixes the link to point to my new URL. Sorry for any troubles! closes #120 